### PR TITLE
chore: release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.0] - 2026-04-07
+
+### ➖ Removed
+
+- Drop Neovim 0.10 support by @powerman in [c8c6ed9]
+
+[0.3.0]: https://github.com/powerman/ruscmd.nvim/compare/v0.2.0..v0.3.0
+[c8c6ed9]: https://github.com/powerman/ruscmd.nvim/commit/c8c6ed9a0904380806807e7d5bab97dce1c52a06
+
 ## [0.2.0] - 2025-08-15
 
 [0.2.0]: https://github.com/powerman/ruscmd.nvim/compare/v0.1.1..v0.2.0


### PR DESCRIPTION

### ➖ Removed

- Drop Neovim 0.10 support by @powerman in [c8c6ed9]

[0.3.0]: https://github.com/powerman/ruscmd.nvim/compare/v0.2.0..v0.3.0
[c8c6ed9]: https://github.com/powerman/ruscmd.nvim/commit/c8c6ed9a0904380806807e7d5bab97dce1c52a06